### PR TITLE
Restore view encapsulation as it is a good practise.

### DIFF
--- a/src/app/countries/countries.component.ts
+++ b/src/app/countries/countries.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CountriesService } from './countries.service';
 import ICountry, { simpleFields } from './country/country.model';
 import { Region, SORTED_REGIONS } from './regions/region.model';
@@ -8,7 +8,6 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons';
   selector: 'app-countries',
   templateUrl: './countries.component.html',
   styleUrls: ['./countries.component.scss'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class CountriesComponent implements OnInit {
   faSearch = faSearch;

--- a/src/app/countries/country-grid/country-grid.component.html
+++ b/src/app/countries/country-grid/country-grid.component.html
@@ -1,5 +1,7 @@
 <div class="country-grid">
-  <div class="country" *ngFor="let country of countries">
-    <app-country *ngIf="country" [country]="country"></app-country>
-  </div>
+  <app-country
+    class="country"
+    *ngFor="let country of countries"
+    [country]="country"
+  ></app-country>
 </div>

--- a/src/app/countries/country-grid/country-grid.component.scss
+++ b/src/app/countries/country-grid/country-grid.component.scss
@@ -3,16 +3,14 @@ $grid-gap: 40rem;
 .country-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  grid-template-rows: 1fr;
+  grid-auto-rows: 375px;
   column-gap: $grid-gap;
   row-gap: $grid-gap;
-
-  > div {
-    background-color: grayscale($color: #f8f8f8);
-    border: 1px solid lightgrey;
-  }
 }
 
 .country {
   position: relative;
+
+  background-color: grayscale($color: #f8f8f8);
+  border: 1px solid lightgrey;
 }

--- a/src/app/countries/country/country.component.html
+++ b/src/app/countries/country/country.component.html
@@ -9,9 +9,4 @@
   <li><b>Region</b>: {{ country?.region }}</li>
   <li><b>Capital</b>: {{ country?.capital }}</li>
 </ul>
-<fa-icon
-  (click)="onToggleWishList()"
-  [icon]="faHeart"
-  size="2x"
-  [classes]="['heart']"
-></fa-icon>
+<fa-icon (click)="onToggleWishList()" [icon]="faHeart" size="2x"></fa-icon>

--- a/src/app/countries/country/country.component.scss
+++ b/src/app/countries/country/country.component.scss
@@ -20,12 +20,8 @@ ul {
 ul {
   list-style-type: none;
   font-size: 14rem;
-}
 
-.heart {
-  position: absolute;
-  bottom: $padding;
-  right: $padding;
-
-  cursor: pointer;
+  li {
+    line-height: 20rem;
+  }
 }

--- a/src/app/countries/country/country.component.ts
+++ b/src/app/countries/country/country.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Input,
-  OnInit,
-  ViewChild,
-  ViewEncapsulation,
-} from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import ICountry from './country.model';
 import { faHeart } from '@fortawesome/free-solid-svg-icons';
 import { WishListService } from '../wish-list/wish-list.service';
@@ -14,7 +8,6 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
   selector: 'app-country',
   templateUrl: './country.component.html',
   styleUrls: ['./country.component.scss'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class CountryComponent implements OnInit {
   faHeart = faHeart;
@@ -24,8 +17,14 @@ export class CountryComponent implements OnInit {
   @Input() country!: ICountry;
 
   private onWishList = false;
-  private readonly wishListHeartOn = { stroke: '#ff0000', color: '#ff0000' };
-  private readonly wishListHeartOff = { stroke: 'ff0000', color: 'faa0a0' };
+  private readonly wishListHeartOn = {
+    position: 'absolute',
+    bottom: '12rem',
+    right: '12rem',
+    stroke: '#ff0000',
+    color: '#ff0000',
+  };
+  private wishListHeartOff = { ...this.wishListHeartOn, color: '#faa0a0' };
 
   constructor(private wishListService: WishListService) {}
 


### PR DESCRIPTION
Move heart styling logic completely to component for 2 reasons:

1. To separate concerns as it is done dynamically anyway.
2. Using stylesheets has issues and only seems to work from the root scss file.
Seems like that is the only point at which the styles are in the DOM.